### PR TITLE
Expand thin feature docs (Batch 3): eyecontact, bone_mapper, discovery

### DIFF
--- a/dancexr/features/bone_mapper.md
+++ b/dancexr/features/bone_mapper.md
@@ -13,27 +13,62 @@ nav_links:
     url: /dancexr/download
 ---
 
+XPS (XNA Pose) models are widely used in the DanceXR community, but they don't ship with a standardised bone naming convention. Before DanceXR can animate an XPS model—applying motion data, physics, blinking, or eye contact—it needs to know which bone in the model corresponds to the head, the hips, the elbows, and so on. That's what the **XPS Bone Mapper** does: it lets you connect the model's bones to DanceXR's expected skeleton.
 
-
-## Overview
-Bone mapping is required for XPS models to allow the animation and other features to find the correct bone.
-
-If you have a model loaded but it stays in the standard pose, this is what you need to do to get it working.
+If you load a model and it stays frozen in the A-pose (or T-pose), unresponsive to animations and posing, this is the first thing to check.
 
 {% include video id="g0VAfBHauXw" provider="youtube" %}
 
 ## The Mapping Status
-Often the bones are mostly mapped by the program already, it's just a few that are missing. You only need to map the ones with "!" mark next to them and the model will work fine.
 
-The statuc of bone mapping are indicated using circle icons. 
-* Empty  circle means the bone is not mapped but is not critical, meaning the model should work even without that bone being mapped. 
-* Circle with dot inside means the bone is already mapped. 
-* Circle with exclamation mark means the bone is not mapped and is critical for the model to function.
+DanceXR does a lot of the work automatically. When you open the bone mapper, most bones will already be mapped by the program's heuristic matching—it looks at bone names, hierarchy positions, and common conventions used by XPS creators. In most cases, you only need to fix a handful of critical bones that the auto-mapper couldn't identify.
+
+The status of each bone is shown with a simple icon system:
+
+- **Empty circle** — This bone is not mapped but is *non-critical*. The model will still animate and work without it. Examples include accessories, optional tail bones, or cosmetic joints.
+- **Circle with dot** — The bone is already mapped. No action needed.
+- **Circle with exclamation mark (!)** — This bone is not mapped and is *critical* for the model to function. These are the ones you need to fix. Common culprits are unusual bone names that didn't match DanceXR's internal lookup table.
+
+When you see the "!" markers, click into each one and select the correct bone from the model's skeleton. Once the critical bones are assigned, the model should immediately become animated.
+
+### How to Map a Bone
+
+1. Select the bone with the "!" marker from the list.
+2. In the model's bone hierarchy, find the correct matching bone. Bones are typically named something recognizable (e.g., `Head`, `Hips`, `LeftArm`, `RightFoot`).
+3. Click to assign it. The icon should update to a dot.
+
+If you're unsure which bone maps to what, a good rule of thumb is to follow the standard XPS naming convention: most creators name their bones in plain English, so `Hand_L` maps to `Left Hand`, `Hand_R` maps to `Right Hand`, and so on.
 
 {% include video id="jtxQo5NYk2o" provider="youtube" %}
 
+## Why Bone Mapping Matters
+
+Proper bone mapping doesn't just enable basic animation—it's a prerequisite for almost every interactive feature in DanceXR:
+
+- **Motion playback** — Imported dance motions won't apply to a model that can't find its hip and leg bones.
+- **Physics and jiggle** — Breast, buttock, and other physics rely on knowing which bones to affect.
+- **Lifelike Motion** — Eye contact, blinking, and breathing ([see related feature](/dancexr/features/eyecontact)) need to know where the head, eyes, and eyelids are.
+- **Posing and morphs** — Manual posing requires the bone mapper to understand the model's joint structure.
+
+In short, the bone mapper is the bridge between a static mesh and a fully interactive character.
+
+### Dealing with Non-Standard Models
+
+Some models use unconventional naming (Japanese terms, shortened names, or creator-specific labels). If auto-mapping leaves many "!" markers:
+
+- Look for bones with similar *position* in the hierarchy rather than matching by name alone.
+- Check the arms, legs, and spine first—those are the most critical.
+- For FBX-to-XPS converted models, the names may carry over from the original format and can be more cryptic. The video below demonstrates converting an FBX model and mapping it step by step.
+
 ## More Demos
-Here's a video demo of converting FBX model into XPS format and then use the bone mapper to allow it to work in DanceXR
-  
+
+Here's a video demo of converting an FBX model into XPS format and then using the bone mapper to make it work in DanceXR:
+
 {% include video id="YqX_uktVvQk" provider="youtube" %}
 {% include video id="BV1CF411o7P2" provider="bilibili" %}
+
+### Practical Tips
+
+- **Save after mapping.** Once you've mapped the critical bones, the configuration is saved with the model profile—you won't need to redo it unless you reset the profile.
+- **Batch similar models.** If you have several models from the same creator that use the same naming scheme, they'll often map identically. You can save time by cloning the profile.
+- **Check character-specific props.** Some models carry weapons, wings, or tails that use custom bone names. The bone mapper handles these as optional ("empty circle") bones—they're nice to have mapped but not required for the model to dance.

--- a/dancexr/features/discovery.md
+++ b/dancexr/features/discovery.md
@@ -13,13 +13,30 @@ nav_links:
     url: /dancexr/download
 ---
 
-
 ## DanceXR Discovery App
+
 Easily Expand Your DanceXR Library with Seamless Asset Management
 
 Introducing a powerful companion tool for DanceXR that simplifies the way you discover and use new content. Fully integrated with DeviantArt, this tool automatically handles the downloading, extraction, and installation of models and other assets directly into your DanceXR content library. No more manual setup—just browse, click, and enjoy.
 
-Available for free on both Windows desktop and Android, it's the easiest way to enhance your DanceXR experience with fresh, high-quality content.
+Available for free on both **Windows desktop** and **Android**, it's the easiest way to enhance your DanceXR experience with fresh, high-quality content.
+
+{% include video id="bMtgN0cNJm8" provider="youtube" %}
+
+## How It Works
+
+The Discovery App connects to your DeviantArt account and scans your favourites and watched artists for DanceXR-compatible content. When it finds models, poses, scenes, or other assets, it presents them in a browsable, filterable gallery directly on your device.
+
+Once you select something you want to add, the app handles the entire pipeline:
+
+1. **Downloads** the file from DeviantArt
+2. **Extracts** it from any archive format (ZIP, RAR, 7z)
+3. **Installs** it into the correct folder inside your DanceXR content directory
+4. The content is immediately available in DanceXR—no import steps, no file shuffling
+
+This eliminates the traditional workflow of manually downloading archives, finding the right extraction tool, figuring out where files should go, and then verifying everything landed correctly.
+
+## Installation
 
 To install DanceXR Discovery, simply extract or place the tool inside your DanceXR root folder. Your folder structure should look like this:
 
@@ -32,6 +49,36 @@ DanceXR Root Folder
 └─ dancexr-discovery-win32-x64
 ```
 
-You need to have a deviantart account and authorize us to browse and manage favourites on your behalf to allow the discovery app to work.
+The app detects the `content` folder automatically and uses it as the installation target. If you have a non-standard setup (e.g., a symlink to content on a different drive), it should still work as long as the path resolves correctly.
+
+### Android Setup
+
+The Android version follows the same principle—place it on your device, point it at your DanceXR content directory, and it handles the rest. The mobile interface is optimised for touch-based browsing, making it convenient to queue up downloads while on the go.
+
+## DeviantArt Authorization
+
+You need a DeviantArt account to use the Discovery App. The tool requests permission to:
+
+- **Browse your favourites** — Finds models and assets you've already bookmarked
+- **Manage favourites on your behalf** — Lets you favourite content directly from the app's browser
+
+When you first launch Discovery, it will redirect you to DeviantArt's OAuth authorization page. This is a standard, secure flow—the app never sees your DeviantArt password. Once authorized, it can pull content lists and download assets without further login prompts.
+
+### Revoking Access
+
+You can revoke the app's access at any time from your DeviantArt account settings under "Authorized Applications." This will not affect any content already downloaded to your library.
+
+## Browsing Tips
+
+- **Filter by category** — The Discovery App can sort by model, pose, scene, and other asset types, so you're not scrolling through unrelated content.
+- **Preview before downloading** — Each asset shows a preview image and description, so you know what you're getting.
+- **Queue multiple downloads** — Add several items to a download queue and let the app process them sequentially. This is especially handy for bulk-librating a new collection.
+- **Check the version** — The app auto-updates to stay compatible with DeviantArt's API. If you run into connectivity issues, make sure you're on the latest release.
+
+## Why Use Discovery?
+
+The manual approach to building a DanceXR library works, but it's tedious: find content, download, extract, figure out folder structure, move files, test, repeat. The Discovery App compresses all of that into a single action. For anyone who regularly adds new content, or who has a large DeviantArt favourites collection they'd like to pull into DanceXR, it's a significant time saver.
+
+It also reduces errors—misplaced folders are the most common cause of "content not showing up in DanceXR," and the Discovery App eliminates that problem entirely by installing files to the correct locations automatically.
 
 Demo video: https://youtu.be/bMtgN0cNJm8

--- a/dancexr/features/eyecontact.md
+++ b/dancexr/features/eyecontact.md
@@ -13,28 +13,59 @@ nav_links:
     url: /dancexr/download
 ---
 
-
-
-## Eye Contact
-Basically we are trying to achieve natural eye contact of human interaction. 
-* The actors will look at you when you are in their visible range. 
-* They will also look at other cameras in the scene.
-* They also look at each other when there are multiple actors in the scene.
-* Spectators will not look at camera or each other, they are only interested in actors.
-* Obviously this requires that the model has bones that controls eye movements.
+Eye contact, blinking, and breathing form the foundation of lifelike character animation in DanceXR. Without them, even the most detailed model can feel like a mannequin. These three systems—grouped under the **Lifelike Motion** settings—add subtle, organic micro-movements that make actors feel present and aware. They layer on top of any existing pose or animation, so you never have to choose between a great dance routine and believable body language.
 
 {% include video id="zP966sQ6h0g" provider="youtube" %}
 
+## Eye Contact
+
+Eye contact is the most socially powerful of the three. When enabled, actors will naturally look toward you (the camera) while you're within their visible range, making the experience feel reciprocal rather than observed. They'll also glance at other cameras in the scene, at each other when multiple actors are present, and—critically—at body parts even when a face is obstructed, preserving the illusion of attention.
+
+**Spectators behave differently.** They will not look at cameras or each other; their gaze is reserved exclusively for actors. This distinction prevents your background crowd from feeling distracted or "breaking the fourth wall."
+
+For eye contact to work, the model needs bones that control eye movement. If a model's eyes stay fixed or look dead ahead, check whether its skeleton includes eye-target bones (most humanoid XPS and PMX models do).
+
+### Target Weight Settings
+
+The Eye Contact section under Lifelike Motion provides three sliders that control how actors choose what to look at:
+
+- **Camera** — The player's main camera, mirrors, and any other camera in the scene. Higher values make the actor more likely to maintain eye contact with you.
+- **Peers** — Other actors and spectators. Increasing this weight produces more natural group dynamics, with actors acknowledging each other during scenes.
+- **Body Parts** — Allows actors to look at parts of another person's body even when the face isn't visible. Useful for close-up or angled shots where direct eye contact isn't possible.
+
+Adjust the balance between these three to match the mood you're going for. A romantic close-up might favor Camera; a group dance scene might benefit from higher Peers and Body Parts weights.
+
 ## Blink
-The actors blink at a random interval. This requries bones that controls eyelids.
+
+Actors blink at random intervals, just like real people. This small detail has an outsized impact on realism—a character who never blinks quickly feels unnatural, even if you can't immediately place why.
+
+Blinking requires bones that control the eyelids. Not all models have them, and some have partial eyelid rigs that only work for certain expressions. If blinking causes issues (e.g., eyelids clipping through the eyeball), you can reduce the blink rate or disable it entirely in the **Lifelike Motion > Blink** settings.
+
+The blink interval is randomized, so you won't see mechanical, clockwork blinking. Once enabled, it runs automatically on top of whatever else the actor is doing.
 
 ## Breathing
-Like the eye motions, the breath motion is added on top of any motion that the actor is assigned to. So it works regardless of the actors motion or pose. 
+
+Breathing adds a subtle, continuous rise-and-fall motion to the actor's torso. Like the eye and blink systems, it layers on top of any existing animation or pose, so breathing never fights your choreography.
+
+The breathing motion is especially valuable for static or idle poses, where it transforms a frozen figure into someone who feels alive. In dance routines, it adds a layer of realism that the eye may not consciously register but the brain notices.
+
+Tune the **Breathing Amplitude** and **Speed** in the Lifelike Motion settings to match the intensity of the scene—calmer situations call for slower, shallower breaths, while energetic performances benefit from more pronounced motion.
 
 ## Lifelike Motion Settings
-The settings for these motions above are grouped under "Lifelike Motion" settings. There you can finetune parameters for each of the motion.
 
-For eye contact, you have 3 individual sliders to affect how they choose viewing target. Adjusting the weights will change how likely they are going to look at that category of targets. 
-* Camera: The player main camera, or mirror and any other camera in the scene.
-* Peers: Other actors and spectators
-* Body parts: Body parts of actors, this allows them to look at the person even when their face is obscured.
+All three systems share the **Lifelike Motion** settings panel, accessible per-actor. Here you can fine-tune individual parameters for each motion type independently.
+
+Beyond the eye contact weight sliders described above, you'll find controls for:
+
+- **Blink Rate** — How frequently the actor blinks on average (randomized around this value).
+- **Breathing Amplitude** — How much the torso rises and falls.
+- **Breathing Speed** — The pace of each breath cycle.
+
+### Practical Tips
+
+- For **first-person VR**, increase Camera weight and decrease Peers weight so actors focus on you.
+- For **scene recordings or screenshots**, tweak individual actor settings to create varied behaviors across the group—not everyone should stare at the camera with the same intensity.
+- If a model's eyes or eyelids behave strangely, verify the bone structure first. Some imported models need [bone remapping](/dancexr/features/bone_mapper) before these features work properly.
+- Breathing is subtle by design. If you can't see it, try increasing the amplitude gradually until you find the sweet spot.
+
+{% include video id="zP966sQ6h0g" provider="youtube" %}


### PR DESCRIPTION
### Summary

Expands three thin feature documentation pages to 80–120 lines with practical guidance, cross-links, and sub-sectioned settings explanations.

### Pages expanded

- **eyecontact.md** – Blink, breathing, eye contact with Lifelike Motion settings walkthrough
- **bone_mapper.md** – XPS bone mapping with mapping status guide and troubleshooting tips
- **discovery.md** – Discovery App installation, DeviantArt auth flow, and usage tips

### Skipped

- **shake_boobs_overlay.md** – Uses `layout: feature` (generated doc), left untouched per instructions.