### PR TITLE
Fix URL naming mismatches in features page - add orphaned auto_reset link

### DIFF
--- a/dancexr/features.md
+++ b/dancexr/features.md
@@ -489,6 +489,9 @@ feature_sections:
             image: /images/slideshows/physics/6b29c53917daff568a9ee75cfa0d62b6b4cadf79.jpg
             badge: 2026.1
             badge_type: new
+          - title: Auto Reset
+            link: /dancexr/features/auto_reset
+            image: /images/slideshows/load_play/e01294325adee543b4942b0aa5e917dfe7a67394.jpg
           - title: Auto Update
             link: /dancexr/features/autoupdate
             image: /images/slideshows/load_play/4e0d4466664bf1e6fd615d3c69e03b74045bd0c7.jpg


### PR DESCRIPTION
## Changes

- Added missing **Auto Reset** tile linking to `auto_reset.md` in the features page under System & Platform > System section
- Verified all 116 `/dancexr/features/*` links in `features.md` resolve to existing `.md` files
- Verified nav_links point to correct page structure

## Audit results

| Check | Status |
|-------|--------|
| Linked pages that exist | 116/116 ✅ |
| Broken links | 0 ❌ (none found) |
| Orphaned feature pages not linked | `auto_reset.md` — now added ✅ |
| `cloth_simulation.md` | Release doc, not a feature page — no action needed |
| `sm3_motion.md` | Alias for sex_motion_3 — linked as sex_motion_3 ✅ |
